### PR TITLE
Views: Style the Categories view

### DIFF
--- a/src/components/ParcelMap/index.module.scss
+++ b/src/components/ParcelMap/index.module.scss
@@ -41,10 +41,10 @@
 }
 
 .popupCloser {
+  border: 0;
+  border-radius: 0.25rem;
+  float: right;
   text-decoration: none;
-  position: absolute;
-  top: 2px;
-  right: 8px;
 
   &:after {
     content: "✖";

--- a/src/views/Categories/components/EditForm/index.jsx
+++ b/src/views/Categories/components/EditForm/index.jsx
@@ -4,9 +4,11 @@ import {
   Button,
   ButtonVariant,
   Form,
+  FormGroup,
   FormSelect,
   FormSelectOption,
 } from '@patternfly/react-core';
+import styles from './index.module.scss';
 
 /** @typedef {import('api').Parcel} Parcel */
 
@@ -50,15 +52,17 @@ const EditForm = props => {
 
   return (
     <Form onSubmit={handleFormSubmit}>
-      <FormSelect
-        value={parcel.isFireHazard ? 'yes' : 'no'}
-        onChange={handleFireHazardChange}
-        aria-label="Is this parcel a fire hazard?"
-      >
-        <FormSelectOption value="yes" label="Yes" />
-        <FormSelectOption value="no" label="No" />
-      </FormSelect>
-      <ActionGroup>
+      <FormGroup className={styles.formGroup} label="Is this parcel a fire hazard?">
+        <FormSelect
+          value={parcel.isFireHazard ? 'yes' : 'no'}
+          onChange={handleFireHazardChange}
+          aria-label="Is this parcel a fire hazard?"
+        >
+          <FormSelectOption value="yes" label="Yes" />
+          <FormSelectOption value="no" label="No" />
+        </FormSelect>
+      </FormGroup>
+      <ActionGroup className={styles.actionGroup}>
         <Button
           variant={ButtonVariant.secondary}
           onClick={onCancelButtonClick}

--- a/src/views/Categories/components/EditForm/index.module.scss
+++ b/src/views/Categories/components/EditForm/index.module.scss
@@ -1,0 +1,11 @@
+.formGroup {
+  label {
+    font-size: var(--pf-global--FontWeight--normal);
+    line-height: var(--pf-global--LineHeight--md);
+    margin-bottom: 0.35rem;
+  }
+}
+
+.actionGroup {
+  margin-top: 0 !important;
+}

--- a/src/views/Categories/index.module.css
+++ b/src/views/Categories/index.module.css
@@ -1,3 +1,3 @@
 .pageContentContainer {
-  height: 100%;
+  height: 400px;
 }


### PR DESCRIPTION
- Added `FormGroup` to apply a `Label` that's visible on `EditForm`.
- Added CSS for `FormGroup`, `popupCloser`, `ActionGroup`.
- Height of `Bullseye` should only be 400px so it's centered accordingly with the left panel.

Tested on Chrome & Firefox. 

![Screenshot from 2019-11-03 11-35-06](https://user-images.githubusercontent.com/8406707/68091412-25f3cd00-fe34-11e9-946c-2def54d5d110.png)

![Screenshot from 2019-11-03 12-14-06](https://user-images.githubusercontent.com/8406707/68091411-25f3cd00-fe34-11e9-9d7a-526bbcce4277.png)