### PR TITLE
Refactor address search

### DIFF
--- a/src/components/AddressSearch/components/SearchResultsList/index.jsx
+++ b/src/components/AddressSearch/components/SearchResultsList/index.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { List, Button, ListItem } from '@patternfly/react-core';
-import styles from '../index.module.scss';
+import styles from './index.module.scss';
 
-/** @typedef {import('api/index').Parcel} Parcel */
+/** @typedef {import('api').Parcel} Parcel */
 
 /**
  * Lists search results

--- a/src/components/AddressSearch/components/SearchResultsList/index.module.scss
+++ b/src/components/AddressSearch/components/SearchResultsList/index.module.scss
@@ -1,0 +1,15 @@
+.list {
+  list-style: none !important;
+  padding: 0;
+  margin: 1rem 0;
+
+  & > li {
+    padding: 0.25rem 0;
+    margin-top: 0 !important;
+  }
+
+  & > li > button {
+    padding: 0;
+    margin: 0;
+  }
+}

--- a/src/components/AddressSearch/index.module.scss
+++ b/src/components/AddressSearch/index.module.scss
@@ -3,19 +3,3 @@
     margin-bottom: 1rem;
   }
 }
-
-.list {
-  list-style: none !important;
-  padding: 0;
-  margin: 1rem 0;
-
-  & > li {
-    padding: 0.25rem 0;
-    margin-top: 0 !important;
-  }
-
-  & > li > button {
-    padding: 0;
-    margin: 0;
-  }
-}

--- a/src/components/AddressSearch/useAddressSearchStore.js
+++ b/src/components/AddressSearch/useAddressSearchStore.js
@@ -1,0 +1,60 @@
+// @ts-check
+import { useMemo } from 'react';
+import api from 'api';
+import useSetState from '../../hooks/useSetState';
+
+/** @typedef {import('api').Parcel} Parcel */
+
+const initialState = {
+  errorMessage: '',
+  isSearchInProgress: false,
+
+  /** @type {Array<Parcel>} */
+  searchResults: [],
+};
+
+export default function useAddressSearchStore() {
+  const [state, setState] = useSetState(initialState);
+
+  const actions = useMemo(
+    () => {
+      /** @param {string} query */
+      async function search(query) {
+        setState({
+          errorMessage: '',
+          isSearchInProgress: true,
+          searchResults: [],
+        });
+
+        try {
+          const searchResults = await api.parcels.search(query);
+
+          // Store results in state
+          setState({
+            isSearchInProgress: false,
+            searchResults,
+          });
+        } catch {
+          // Request was unsuccessful
+          setState({
+            isSearchInProgress: false,
+            errorMessage: 'An error occurred',
+          });
+        }
+      }
+
+      return { search };
+    },
+    [setState],
+  );
+
+  const store = useMemo(
+    () => ({
+      ...state,
+      ...actions,
+    }),
+    [actions, state],
+  );
+
+  return store;
+}

--- a/src/hooks/useSetState.js
+++ b/src/hooks/useSetState.js
@@ -1,0 +1,38 @@
+// @ts-check
+import { useReducer } from 'react';
+
+/**
+ * @callback StateChangesReducer
+ * @param {State} prevState - Previous state
+ * @returns {Partial<State>} - Patch for new state. This should be an object with some or all of
+ *     the properties from the previous state.
+ * @template {Object} State
+ */
+
+/**
+ * @param {State} state
+ * @param {Partial<State> | StateChangesReducer<State>} stateChanges
+ * @template {Object} State
+ */
+
+function reducer(state, stateChanges) {
+  const patch = typeof stateChanges === 'object'
+    ? stateChanges
+    : stateChanges(state);
+
+  return {
+    ...state,
+    ...patch,
+  };
+}
+
+/**
+ * React hook that provides functionality similar to a class component's `this.useState` method
+ * @param {State} initialState
+ * @returns {[State, function(Partial<State> | StateChangesReducer<State>)]}
+ * @template {Object} State
+ */
+export default function useSetState(initialState) {
+  const [state, setState] = useReducer(reducer, initialState);
+  return [state, setState];
+}

--- a/src/views/Categories/index.jsx
+++ b/src/views/Categories/index.jsx
@@ -10,6 +10,7 @@ import {
 } from '@patternfly/react-core';
 import AddressSearch from 'components/AddressSearch';
 import ParcelMap from 'components/ParcelMap';
+import useAddressSearchStore from 'components/AddressSearch/useAddressSearchStore';
 import EditForm from './components/EditForm';
 import styles from './index.module.css';
 
@@ -26,7 +27,8 @@ const ChooseParcelText = () => (
 
 const Categories = () => {
   const [selectedParcel, setSelectedParcel] = useState(selectedParcelInitialState);
-  const [hasSearchResults, setHasSearchResults] = useState(false);
+
+  const addressSearchStore = useAddressSearchStore();
 
   const handleCancelButtonClick = () => {
     // Deselect the parcel
@@ -35,10 +37,16 @@ const Categories = () => {
 
   const handleSaveButtonClick = parcel => {
     // TODO: Send parcel updates to backend
-    setSelectedParcel(parcel);
+
+    // Deselect the parcel
+    setSelectedParcel(selectedParcelInitialState);
   };
 
-  const expandedContent = selectedParcel || hasSearchResults;
+  const expandedContent = Boolean(
+    selectedParcel
+    || addressSearchStore.isSearchInProgress
+    || addressSearchStore.searchResults.length,
+  );
 
   const classes = expandedContent ? `${styles.card} ${styles.expanded}` : `${styles.card}`;
 
@@ -49,8 +57,8 @@ const Categories = () => {
       <Card className={classes}>
         <CardBody>
           <AddressSearch
+            store={addressSearchStore}
             onSelectParcel={setSelectedParcel}
-            onHasSearchResults={setHasSearchResults}
           />
           {
           selectedParcel

--- a/src/views/Notifier/index.jsx
+++ b/src/views/Notifier/index.jsx
@@ -8,6 +8,7 @@ import {
   Text,
 } from '@patternfly/react-core';
 import AddressSearch from 'components/AddressSearch';
+import useAddressSearchStore from 'components/AddressSearch/useAddressSearchStore';
 import NotifyForm from './components/NotifyForm';
 import styles from './index.module.css';
 
@@ -24,6 +25,7 @@ const ChooseParcelText = () => (
 
 const Notifier = () => {
   const [selectedParcel, setSelectedParcel] = useState(selectedParcelInitialState);
+  const addressSearchStore = useAddressSearchStore();
 
   const handleCancelButtonClick = () => {
     // Deselect the parcel
@@ -39,7 +41,7 @@ const Notifier = () => {
 
   return (
     <PageSection variant={PageSectionVariants.light} className={styles.pageSection}>
-      <AddressSearch onSelectParcel={setSelectedParcel} />
+      <AddressSearch store={addressSearchStore} onSelectParcel={setSelectedParcel} />
 
       <Card className={classes}>
         <CardBody>


### PR DESCRIPTION
This PR moves the `AddressSearch` component's state into an external React hook using the store pattern.

This is necessary so the "category" and "notifier" views can have access to the search results.